### PR TITLE
chore!: Drop support for Node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [16]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
       - name: Install dependencies
         run: npm ci
       - name: Lint


### PR DESCRIPTION
BREAKING CHANGE: Node 12 features aren't supported anymore

JIRA: https://openedx.atlassian.net/browse/BOM-3296