### PR TITLE
feat: include airbnb/hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     // have those eslint-config plugins installed, though - it defines them
     // as peer dependencies.
     'airbnb',
+    'airbnb/hooks',
   ],
   // If you add rule overrides here, add code to test.js that proves you formatted it right.
   rules: {


### PR DESCRIPTION
https://github.com/openedx/frontend-wg/issues/99

BREAKING CHANGE: By extending airbnb/hooks, consumers of this library will now get ESLint errors about React Hooks:

1. Rules of Hooks.
2. Exhaustive dependencies.

See https://github.com/airbnb/javascript/blob/fdc812a0a5773449274f7c4d473e0841eca89614/packages/eslint-config-airbnb/rules/react-hooks.js#L12-L20 for more details.