### PR TITLE
feat: add support for `es2020` syntax in shared eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     es6: true,
     browser: true,
     jest: true,
+    es2020: true,
   },
   extends: [
     // The airbnb config includes configuraton for import, react, and jsx-a11y.

--- a/test.jsx
+++ b/test.jsx
@@ -24,3 +24,6 @@ class MethodDoesNotUseThis {
 // disable no-plusplus
 let i = 0;
 i++;
+
+// globalThis is allowed
+const value = globalThis.localStorage.getItem('foo');


### PR DESCRIPTION
Inspired by this [comment thread](https://github.com/openedx/frontend-platform/pull/701#discussion_r1644915761), this PR  adds support for `es2020` syntax. The primary rationale is that given we are to beginning to support `globalThis` syntax in shared JS libraries and MFEs, we should ensure other related ES2020 syntax is included as well, and implemented in such a way that is common/applicable as opposed to being added to individual ESLint configs. The Open edX platform officially supports the browsers defined in `@edx/browserslist-config` ([source](https://github.com/openedx/browserslist-config/blob/master/index.js)), where all have support for `es2020` syntax.