### PR TITLE
feat: Don't require defaultProps for function components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,5 +65,12 @@ module.exports = {
     'react/destructuring-assignment': 'off',
     'no-plusplus': 'off',
     strict: 'off',
+    // We don't require 'defaultProps' for function components (they're
+    // deprecated: https://github.com/facebook/react/pull/16210).
+    // It's better to use native JavaScript/TypeScript defaults and TS types.
+    'react/require-default-props': ['error', {
+      classes: 'defaultProps',
+      functions: 'ignore',
+    }],
   },
 };


### PR DESCRIPTION
I think `react/require-default-props` is an annoying rule in TSX files, as often it's perfectly fine to have `undefined` as the default value of a prop, and TypeScript already forces you to handle it accordingly in your component implementation.

But eslint currently wants us to add a default value for no reason. See example below, where eslint complains that three of the props lack defaults, even though 2 have a default and the third makes sense to have no default.

<img width="631" alt="Screenshot 2024-07-12 at 12 16 01 PM" src="https://github.com/user-attachments/assets/26f4e951-5940-4aec-afdb-5ce4b8aea853">


In this example, we don't need `onToggleChildren` to have a default value of an empty function, because TypeScript will make sure we call it as `onToggleChildren?.(path);` to handle the case where it's undefined. Or the author may choose to add a default, but in any case there's no errors nor incorrect code resulting from a missing default, so I don't believe the eslint rule is providing any value at all.