### PR TITLE
Disable the "prefer-default-export" rule and "no-restricted-syntax"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,8 @@ module.exports = {
     // but we had 'prefer-default-export' on for a long time so we can't turn on 'no-default-export' without causing
     // a large refactor.
     'import/prefer-default-export': 'off',
+    // There is no reason to disallow this syntax anymore; we don't use regenerator-runtime in new browsers
+    'no-restricted-syntax': 'off',
     'jsx-a11y/label-has-associated-control': ['error', {
       labelComponents: [],
       labelAttributes: [],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,10 @@ module.exports = {
       },
     ],
     'arrow-parens': 'off',
+    // Avoiding default exports is recommended (https://dev.to/phuocng/avoid-using-default-exports-a1c)
+    // but we had 'prefer-default-export' on for a long time so we can't turn on 'no-default-export' without causing
+    // a large refactor.
+    'import/prefer-default-export': 'off',
     'jsx-a11y/label-has-associated-control': ['error', {
       labelComponents: [],
       labelAttributes: [],


### PR DESCRIPTION
I'm proposing two changes to our eslint config:

1. Disable the `import/prefer-default-export` rule.
   * [This article](https://dev.to/phuocng/avoid-using-default-exports-a1c) has a good summary of the reasons why many developers (like myself) avoid default exports entirely.
   * Another reason not mentioned in the article is that [default exports require this weird syntax to mock with Jest](https://github.com/openedx/frontend-app-authoring/blob/85b57301140deb776ed402a194568411d00ba234/src/CourseAuthoringRoutes.test.jsx#L26) and it's a frequent source of confusion and mistakes when mocking components out for testing.
   * Note that the Authoring MFE currently disables this rule in over 100 files using `/* eslint-disable ` directives, and there are [many more such instances](https://github.com/search?q=org%3Aopenedx+import%2Fprefer-default-export&type=code) in our codebases.
   * I would love to replace it with the `no-default-export` rule, but that would be too disruptive.
3. The `no-restricted-syntax` prevents use of some modern syntax like iterators, but this rule is not needed anymore now that browsers support all that native syntax already. It's not a performance problem anymore like the rule used to be for.